### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/src/CasADi.jl
+++ b/src/CasADi.jl
@@ -12,7 +12,7 @@ export CasadiSymbolicObject, SX, MX, DM
 export casadi, to_julia, substitute
 export nlpsol, qpsol, solve!, solve
 export Opti, variable!, subject_to!, minimize!, parameter!, set_initial!, set_value!,
-       solver!, value, return_status
+    solver!, value, return_status
 
 include("types.jl")
 include("math.jl")
@@ -24,7 +24,7 @@ include("solvers.jl")
 
 const casadi = PythonCall.pynew()
 function __init__()
-    PythonCall.pycopy!(casadi, pyimport("casadi"))
+    return PythonCall.pycopy!(casadi, pyimport("casadi"))
 end
 
 end # module

--- a/src/array_utils.jl
+++ b/src/array_utils.jl
@@ -1,29 +1,39 @@
 ## Indexing
 # Optimized single Int index - avoids intermediate range allocation
 function Base.getindex(x::T, j::Int) where {T <: CasadiSymbolicObject}
-    T(pygetitem(x.x, j - 1))
+    return T(pygetitem(x.x, j - 1))
 end
 
 function Base.getindex(x::T, j::Union{UnitRange{Int}, Colon}) where {T <: CasadiSymbolicObject}
-    T(pygetitem(x.x, (1:length(x))[j] .- 1))
+    return T(pygetitem(x.x, (1:length(x))[j] .- 1))
 end
 
 # Optimized 2D Int indexing
 function Base.getindex(x::T, j1::Int, j2::Int) where {T <: CasadiSymbolicObject}
-    T(pygetitem(x.x, (j1 - 1, j2 - 1)))
+    return T(pygetitem(x.x, (j1 - 1, j2 - 1)))
 end
 
-function Base.getindex(x::T, j1::Union{Int, UnitRange{Int}, Colon},
-        j2::Union{Int, UnitRange{Int}, Colon}) where {T <: CasadiSymbolicObject}
+function Base.getindex(
+        x::T, j1::Union{Int, UnitRange{Int}, Colon},
+        j2::Union{Int, UnitRange{Int}, Colon}
+    ) where {T <: CasadiSymbolicObject}
     (m, n) = size(x)
-    T(pygetitem(x.x, (
-        (1:m)[j1 isa Int ? (j1:j1) : j1] .- 1, (1:n)[j2 isa Int ? (j2:j2) : j2] .- 1)))
+    return T(
+        pygetitem(
+            x.x, (
+                (1:m)[j1 isa Int ? (j1:j1) : j1] .- 1, (1:n)[j2 isa Int ? (j2:j2) : j2] .- 1,
+            )
+        )
+    )
 end
 
-function Base.setindex!(x::CasadiSymbolicObject, v::Number, j::Union{
-        Int, UnitRange{Int}, Colon})
+function Base.setindex!(
+        x::CasadiSymbolicObject, v::Number, j::Union{
+            Int, UnitRange{Int}, Colon,
+        }
+    )
     pysetitem(x.x, (1:length(x))[j isa Int ? (j:j) : j] .- 1, v)
-    x
+    return x
 end
 
 function Base.setindex!(
@@ -31,13 +41,15 @@ function Base.setindex!(
         v::Number,
         j1::Union{Int, UnitRange{Int}, Colon},
         j2::Union{Int, UnitRange{Int}, Colon}
-)
+    )
     (m, n) = size(x)
     J1 = j1 isa Int ? (j1:j1) : j1
     J2 = j2 isa Int ? (j2:j2) : j2
-    pysetitem(
+    return pysetitem(
         x.x, (
-            (1:m)[j1 isa Int ? (j1:j1) : j1] .- 1, (1:n)[j2 isa Int ? (j2:j2) : j2] .- 1), v)
+            (1:m)[j1 isa Int ? (j1:j1) : j1] .- 1, (1:n)[j2 isa Int ? (j2:j2) : j2] .- 1,
+        ), v
+    )
 end
 
 Base.lastindex(x::CasadiSymbolicObject) = length(x)
@@ -45,10 +57,10 @@ Base.lastindex(x::CasadiSymbolicObject, j::Int) = size(x, j)
 
 ## one, zero, zeros, ones
 function Base.one(::Type{C}) where {C <: CasadiSymbolicObject}
-    C(getproperty(casadi, Symbol(C)).eye(1))
+    return C(getproperty(casadi, Symbol(C)).eye(1))
 end
 function Base.one(x::C) where {C <: CasadiSymbolicObject}
-    if size(x, 1) == size(x, 2)
+    return if size(x, 1) == size(x, 2)
         C(getproperty(casadi, Symbol(C)).eye(size(x, 1)))
     else
         throw(DimensionMismatch("multiplicative identity defined only for square matrices"))
@@ -56,24 +68,24 @@ function Base.one(x::C) where {C <: CasadiSymbolicObject}
 end
 
 function Base.zero(::Type{C}) where {C <: CasadiSymbolicObject}
-    C(getproperty(casadi, Symbol(C)).zeros())
+    return C(getproperty(casadi, Symbol(C)).zeros())
 end
 function Base.zero(x::C) where {C <: CasadiSymbolicObject}
-    C(getproperty(casadi, Symbol(C)).zeros(size(x)))
+    return C(getproperty(casadi, Symbol(C)).zeros(size(x)))
 end
 
 function Base.ones(::Type{C}, j::Integer) where {C <: CasadiSymbolicObject}
-    C(getproperty(casadi, Symbol(C)).ones(j))
+    return C(getproperty(casadi, Symbol(C)).ones(j))
 end
 function Base.ones(::Type{C}, j1::Integer, j2::Integer) where {C <: CasadiSymbolicObject}
-    C(getproperty(casadi, Symbol(C)).ones(j1, j2))
+    return C(getproperty(casadi, Symbol(C)).ones(j1, j2))
 end
 
 function Base.zeros(::Type{C}, j::Integer) where {C <: CasadiSymbolicObject}
-    C(getproperty(casadi, Symbol(C)).zeros(j))
+    return C(getproperty(casadi, Symbol(C)).zeros(j))
 end
 function Base.zeros(::Type{C}, j1::Integer, j2::Integer) where {C <: CasadiSymbolicObject}
-    C(getproperty(casadi, Symbol(C)).zeros(j1, j2))
+    return C(getproperty(casadi, Symbol(C)).zeros(j1, j2))
 end
 
 ## Size related operations
@@ -98,28 +110,28 @@ Base.vcat(x::Vector{T}) where {T <: CasadiSymbolicObject} = T(casadi.vcat(x))
 Base.transpose(x::T) where {T <: CasadiSymbolicObject} = T(casadi.transpose(x))
 Base.adjoint(x::CasadiSymbolicObject) = transpose(x)
 function Base.repeat(x::T, counts::Integer...) where {T <: CasadiSymbolicObject}
-    T(casadi.repmat(x, counts...))
+    return T(casadi.repmat(x, counts...))
 end
 function Base.reshape(x::T, t::Tuple{Int, Int}) where {T <: CasadiSymbolicObject}
-    T(casadi.reshape(x, t))
+    return T(casadi.reshape(x, t))
 end
 Base.inv(x::T) where {T <: CasadiSymbolicObject} = T(casadi.inv(x))
 Base.vec(x::T) where {T <: CasadiSymbolicObject} = T(casadi.vec(x))
 
 # From vector to SX/MX
 function Base.convert(::Type{T}, V::AbstractVector{T}) where {T <: CasadiSymbolicObject}
-    T(casadi.vcat(pyrowlist(V)))
+    return T(casadi.vcat(pyrowlist(V)))
 end
 
 # From matrix to SX/MX
 function Base.convert(::Type{T}, M::AbstractMatrix{T}) where {T <: CasadiSymbolicObject}
-    T(casadi.blockcat(pyrowlist(M)))
+    return T(casadi.blockcat(pyrowlist(M)))
 end
 
 # Convert SX/MX to vector
 function Base.Vector(V::T) where {T <: CasadiSymbolicObject}
     v = pyconvert(Vector, casadi.vertsplit(V))
-    v = map(el -> T(Py(el)), v)
+    return v = map(el -> T(Py(el)), v)
 end
 
 # Convert SX/MX to Matrix{SX/MX}
@@ -128,30 +140,36 @@ function Base.Matrix(M::T) where {T <: CasadiSymbolicObject}
     m = reduce(vcat, pyconvert(Vector, m))
     m = map(el -> T(Py(el)), m)
     i, j = size(M)
-    permutedims(reshape(m, (j, i)))
+    return permutedims(reshape(m, (j, i)))
 end
 
 ## Solve linear systems
 function Base.:\(A::Matrix{C}, b::Vector{C}) where {C <: CasadiSymbolicObject}
-    Vector(C(casadi.solve(C(A), C(b))))
+    return Vector(C(casadi.solve(C(A), C(b))))
 end
 
 function Base.:\(A::AbstractMatrix{C}, b::AbstractMatrix{N}) where {
-        C <: CasadiSymbolicObject, N <: Number}
-    Matrix(C(casadi.solve(C(A), C(b))))
+        C <: CasadiSymbolicObject, N <: Number,
+    }
+    return Matrix(C(casadi.solve(C(A), C(b))))
 end
 
 function Base.:\(A::AbstractMatrix{N}, b::AbstractMatrix{C}) where {
-        C <: CasadiSymbolicObject, N <: Number}
-    Matrix(C(casadi.solve(C(A), C(b))))
+        C <: CasadiSymbolicObject, N <: Number,
+    }
+    return Matrix(C(casadi.solve(C(A), C(b))))
 end
 
-function SymbolicUtils.Code.create_array(::Type{T}, ::Nothing, ::Val{1}, ::Val{dims},
-        elems...) where {T <: CasadiSymbolicObject, dims}
-    T([elems...])
+function SymbolicUtils.Code.create_array(
+        ::Type{T}, ::Nothing, ::Val{1}, ::Val{dims},
+        elems...
+    ) where {T <: CasadiSymbolicObject, dims}
+    return T([elems...])
 end
 
-function SymbolicUtils.Code.create_array(::Type{C}, T, ::Val{1}, ::Val{dims},
-        elems...) where {C <: CasadiSymbolicObject, dims}
-    C(T[elems...])
+function SymbolicUtils.Code.create_array(
+        ::Type{C}, T, ::Val{1}, ::Val{dims},
+        elems...
+    ) where {C <: CasadiSymbolicObject, dims}
+    return C(T[elems...])
 end

--- a/src/math.jl
+++ b/src/math.jl
@@ -9,7 +9,7 @@ Base.abs(x::T) where {T <: CasadiSymbolicObject} = T(casadi.fabs(x))
 Base.exp(x::T) where {T <: CasadiSymbolicObject} = T(casadi.exp(x))
 
 function Base.sum(x::T; dims = :) where {T <: CasadiSymbolicObject}
-    if dims == 1
+    return if dims == 1
         T(casadi.sum1(x))
     elseif dims == 2
         T(casadi.sum2(x))
@@ -24,25 +24,25 @@ end
 
 ## Binary operations
 function +(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.plus(x, _float_if_irrational(y)))
+    return C(casadi.plus(x, _float_if_irrational(y)))
 end
 function -(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.minus(x, _float_if_irrational(y)))
+    return C(casadi.minus(x, _float_if_irrational(y)))
 end
 function /(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.mrdivide(x, _float_if_irrational(y)))
+    return C(casadi.mrdivide(x, _float_if_irrational(y)))
 end
 function ^(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.power(x, _float_if_irrational(y)))
+    return C(casadi.power(x, _float_if_irrational(y)))
 end
 function ^(x::C, y::Integer) where {C <: CasadiSymbolicObject}
-    C(casadi.power(x, _float_if_irrational(y)))
+    return C(casadi.power(x, _float_if_irrational(y)))
 end
 function \(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.solve(x, _float_if_irrational(y)))
+    return C(casadi.solve(x, _float_if_irrational(y)))
 end
 function ×(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.cross(x, _float_if_irrational(y)))
+    return C(casadi.cross(x, _float_if_irrational(y)))
 end
 
 _float_if_irrational(x::Real) = x isa Irrational ? float(x) : x
@@ -53,41 +53,43 @@ function *(x::C, y::Real) where {C <: CasadiSymbolicObject}
     else
         casadi.times(x, _float_if_irrational(y))
     end
-    C(v)
+    return C(v)
 end
 
 *(x::AbstractArray{<:Real}, y::C) where {C <: CasadiSymbolicObject} = C(x) * y
 *(x::C, y::AbstractArray{<:Real}) where {C <: CasadiSymbolicObject} = x * C(y)
 
 function >=(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.ge(x, _float_if_irrational(y)))
+    return C(casadi.ge(x, _float_if_irrational(y)))
 end
 function >(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.gt(x, _float_if_irrational(y)))
+    return C(casadi.gt(x, _float_if_irrational(y)))
 end
 function <=(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.le(x, _float_if_irrational(y)))
+    return C(casadi.le(x, _float_if_irrational(y)))
 end
 function <(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.lt(x, _float_if_irrational(y)))
+    return C(casadi.lt(x, _float_if_irrational(y)))
 end
 function ==(x::C, y::Real) where {C <: CasadiSymbolicObject}
-    C(casadi.eq(x, _float_if_irrational(y)))
+    return C(casadi.eq(x, _float_if_irrational(y)))
 end
 
 function Base.isequal(x::C, y::C) where {C <: CasadiSymbolicObject}
-    pyconvert(Bool, casadi.is_equal(x, y))
+    return pyconvert(Bool, casadi.is_equal(x, y))
 end
 Base.iszero(x::C) where {C <: CasadiSymbolicObject} = pyconvert(Bool, x.x.is_zero())
 
 ## Symbolic substitution
-function substitute(ex::Union{C, AbstractVector{C}, AbstractMatrix{C}},
-        vars, vals) where {C <: CasadiSymbolicObject}
+function substitute(
+        ex::Union{C, AbstractVector{C}, AbstractMatrix{C}},
+        vars, vals
+    ) where {C <: CasadiSymbolicObject}
     v = if (vars isa AbstractMatrix{C} && vals isa AbstractMatrix) ||
-           (vars isa AbstractVector{C}) || (vars isa C && vals isa Number)
+            (vars isa AbstractVector{C}) || (vars isa C && vals isa Number)
         casadi.substitute(C(ex), C(vars), C(vals))
     else
         error()
     end
-    C(v)
+    return C(v)
 end

--- a/src/opti.jl
+++ b/src/opti.jl
@@ -7,65 +7,65 @@ struct OptiSol
 end
 
 function Opti()
-    Opti(casadi.Opti())
+    return Opti(casadi.Opti())
 end
 
 function variable!(opti::Opti, dims...)
-    MX(opti.py._variable(dims...))
+    return MX(opti.py._variable(dims...))
 end
 
 function parameter!(opti::Opti, dims...)
-    MX(opti.py._parameter(dims...))
+    return MX(opti.py._parameter(dims...))
 end
 
 function set_value!(opti::Opti, p::MX, val)
-    opti.py.set_value(p, val)
+    return opti.py.set_value(p, val)
 end
 
 function set_initial!(opti::Opti, x::MX, val)
-    opti.py.set_initial(x, val)
+    return opti.py.set_initial(x, val)
 end
 
 function subject_to!(opti::Opti, expr::MX)
-    opti.py._subject_to(expr)
+    return opti.py._subject_to(expr)
 end
 
 function minimize!(opti::Opti, expr::MX)
-    opti.py.minimize(expr)
+    return opti.py.minimize(expr)
 end
 
 function solver!(opti::Opti, solver::String, plugin_options::Dict = Dict(), solver_options::Dict = Dict())
     for (k, v) in solver_options
         v isa Dict && (solver_options[k] = PyDict(v))
     end
-    opti.py.solver(solver, PyDict(plugin_options), PyDict(solver_options))
+    return opti.py.solver(solver, PyDict(plugin_options), PyDict(solver_options))
 end
 
 function solve!(opti::Opti)
     psol = opti.py.solve()
-    OptiSol(psol)
+    return OptiSol(psol)
 end
 
 function value(sol::OptiSol, expr::MX)
     vals = pyconvert(Any, sol.py.value(expr))
-    to_julia(MX(vals))
+    return to_julia(MX(vals))
 end
 
 function debug_value(opti::Opti, expr::MX)
     vals = pyconvert(Any, opti.py.debug.value(expr))
-    to_julia(MX(vals))
+    return to_julia(MX(vals))
 end
 
 function return_status(opti::Opti)
-    pyconvert(String, opti.py.return_status())
+    return pyconvert(String, opti.py.return_status())
 end
 
 function Base.copy(opti::Opti)
-    Opti(opti.py.copy())
+    return Opti(opti.py.copy())
 end
 
 function Base.getproperty(opti::Opti, sym::Symbol)
-    if sym == :x
+    return if sym == :x
         MX(getfield(opti, :py).x)
     elseif sym == :p
         MX(getfield(opti, :py).y)

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -9,7 +9,7 @@ function nlpsol(name::String, solver::String, var_dict::Dict, solver_options::Di
     for (k, v) in solver_options
         v isa Dict && (solver_options[k] = PyDict(v))
     end
-    CasadiFunction(casadi.nlpsol(name, solver, PyDict(var_dict), PyDict(solver_options)))
+    return CasadiFunction(casadi.nlpsol(name, solver, PyDict(var_dict), PyDict(solver_options)))
 end
 
 """
@@ -19,14 +19,14 @@ function qpsol(name::String, solver::String, vardict::Dict, solver_options::Dict
     for (k, v) in solver_options
         v isa Dict && (solver_options[k] = PyDict(v))
     end
-    CasadiFunction(casadi.qpsol(name, solver, PyDict(var_dict), PyDict(solver_options)))
+    return CasadiFunction(casadi.qpsol(name, solver, PyDict(var_dict), PyDict(solver_options)))
 end
 
 """
 casadi.integrator
 """
 function integrator()
-    CasadiFunction(casadi.integrator())
+    return CasadiFunction(casadi.integrator())
 end
 
 """
@@ -40,5 +40,5 @@ function solve(solver::CasadiFunction; x0::Vector = error("Must provide x0."))
         val = sol[k]
         jsol[k] = to_julia(DM(Py(val)))
     end
-    jsol
+    return jsol
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,7 +21,7 @@ _tonparr(a::AbstractArray) = Py(a).__array__()
 ## text/plain
 
 function Base.getproperty(o::C, s::Symbol) where {C <: CasadiSymbolicObject}
-    if s in fieldnames(C)
+    return if s in fieldnames(C)
         getfield(o, s)
     else
         pyconvert(Any, getproperty(o.x, s))

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,7 +1,7 @@
 J = b -> pyconvert(Bool, b)
 
 function test_constructors(::Type{T}) where {T <: CasadiSymbolicObject}
-    @macroexpand @testset "$( string("Construct constant ", T, " from scalar, Vector, Matrix") )" begin
+    @macroexpand @testset "$(string("Construct constant ", T, " from scalar, Vector, Matrix"))" begin
         scalar1 = T(1)
         scalar2 = T(1.0)
         V = T([1; 2; 3])
@@ -11,17 +11,24 @@ function test_constructors(::Type{T}) where {T <: CasadiSymbolicObject}
         @test J(casadi.is_equal(eval(Meta.parse(string("casadi.", T)))(1.0), scalar2, 1))
         @test J(casadi.is_equal(scalar1, scalar2, 1))
         @test J(casadi.is_equal(eval(Meta.parse(string("casadi.", T)))([1; 2; 3]), V, 1))
-        @test J(casadi.is_equal(
-            eval(Meta.parse(string("casadi.", T)))([
-                [1, 2], [3, 4], [5, 6]]), M, 1))
+        @test J(
+            casadi.is_equal(
+                eval(Meta.parse(string("casadi.", T)))(
+                    [
+                        [1, 2], [3, 4], [5, 6],
+                    ]
+                ), M, 1
+            )
+        )
     end
 
-    @testset "$( string("Construct variable ", T, " vector and matrix          ") )" begin
+    @testset "$(string("Construct variable ", T, " vector and matrix          "))" begin
         v = eval(Meta.parse(string("casadi.", T, ".sym")))("v", 3)
         V = T("V", 3)
         v_val = rand(3)
         @test pyconvert(
-            Bool, casadi.is_equal(casadi.substitute(v, v, v_val), casadi.substitute(V, V, v_val), 1))
+            Bool, casadi.is_equal(casadi.substitute(v, v, v_val), casadi.substitute(V, V, v_val), 1)
+        )
 
         m = eval(Meta.parse(string("casadi.", T, ".sym")))("m", 2, 4)
         M = T("M", 2, 4)
@@ -29,7 +36,7 @@ function test_constructors(::Type{T}) where {T <: CasadiSymbolicObject}
         @test J(casadi.is_equal(casadi.substitute(m, m, m_val), casadi.substitute(M, M, m_val), 1))
     end
 
-    @testset "$( string("AbstractFloat and Integer constructors for ", T, "    ") )" begin
+    @testset "$(string("AbstractFloat and Integer constructors for ", T, "    "))" begin
         af = [1.2; -0.0; -4.3]
         @test J(casadi.is_equal(T(af)', casadi.transpose(eval(Meta.parse(string("casadi.", T)))(af)), 2))
 
@@ -37,7 +44,7 @@ function test_constructors(::Type{T}) where {T <: CasadiSymbolicObject}
         @test J(casadi.is_equal(T(int)', casadi.transpose(eval(Meta.parse(string("casadi.", T)))(int)), 2))
     end
 
-    @testset "$( string("Other constructors tests for ", T, "                  ") )" begin
+    return @testset "$(string("Other constructors tests for ", T, "                  "))" begin
         x = T("x")
         @test J(casadi.is_equal(T(x), x))
 

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -1,7 +1,7 @@
 J = b -> pyconvert(Bool, b)
 
 function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
-    @testset "$( string("Transform ", T, " to null, scalar, Vector, and Matrix ") )" begin
+    @testset "$(string("Transform ", T, " to null, scalar, Vector, and Matrix "))" begin
         null_symbol = T("null_symbol", 0)
         scalar = T("scalar", 1)
         V = T("V1", 3) - T("V2", 3)
@@ -18,7 +18,7 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         @test size(M, 2) == 4
     end
 
-    @testset "$( string("Get index for ", T, "                                 ") )" begin
+    @testset "$(string("Get index for ", T, "                                 "))" begin
         s = randn()
         S = T(s)
         v = randn(4)
@@ -47,7 +47,7 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         @test to_julia(M[1:3, :]) ≈ m[1:3, :]
     end
 
-    @testset "$( string("Set index for ", T, "                                 ") )" begin
+    @testset "$(string("Set index for ", T, "                                 "))" begin
         s = randn()
         S = T(s)
         v = randn(4)
@@ -111,7 +111,7 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         @test to_julia(M) ≈ m
     end
 
-    @testset "$( string("Last index for ", T, "                                ") )" begin
+    @testset "$(string("Last index for ", T, "                                "))" begin
         s = randn()
         S = T(s)
         v = randn(4)
@@ -132,7 +132,7 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         @test to_julia(M[end, end]) ≈ m[end]
     end
 
-    @testset "$( string("One, zero, ones, zeros for ", T, "                    ") )" begin
+    @testset "$(string("One, zero, ones, zeros for ", T, "                    "))" begin
         @test to_julia(one(T)) == 1.0
         @test to_julia(one(T("x", 5, 5))) == one(zeros(5, 5))
         @test_throws DimensionMismatch(
@@ -149,7 +149,7 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         @test to_julia(zeros(T, 1, 9)) == zeros(1, 9)
     end
 
-    @testset "$( string("Size related operations for ", T, "                   ") )" begin
+    @testset "$(string("Size related operations for ", T, "                   "))" begin
         @test size(zeros(T, 3), 1) == 3
         @test size(zeros(T, 3), 2) == 1
         @test size(ones(T, 4, 5), 1) == 4
@@ -160,14 +160,14 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         )
     end
 
-    @testset "$( string("Concatenations for ", T, "                            ") )" begin
+    @testset "$(string("Concatenations for ", T, "                            "))" begin
         M = rand(3, 3)
 
         @test to_julia(hcat([T(M); T(M)])) ≈ hcat(M, M)
         @test to_julia(vcat([T(M); T(M)])) ≈ vcat(M, M)
     end
 
-    @testset "$( string("Matrix operations for ", T, "                         ") )" begin
+    @testset "$(string("Matrix operations for ", T, "                         "))" begin
         m = rand(5, 3)
         s = rand(6, 6)
         M = T(m)
@@ -177,7 +177,7 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         @test to_julia(repeat(M, 2, 3)) ≈ repeat(m, 2, 3)
     end
 
-    @testset "$( string("Broadcasting for ", T, "                              ") )" begin
+    @testset "$(string("Broadcasting for ", T, "                              "))" begin
         m₁ = rand(3, 6)
         M₁ = T(m₁)
         m₂ = rand(3, 6)
@@ -191,7 +191,7 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         @test to_julia(M₁ .^ 2.1) ≈ m₁ .^ 2.1
     end
 
-    @testset "$( string("Return types for ", T, "                              ") )" begin
+    @testset "$(string("Return types for ", T, "                              "))" begin
         M = T(rand(5, 3))
         S = T(rand(6, 6))
 
@@ -202,14 +202,14 @@ function test_generic(::Type{T}) where {T <: CasadiSymbolicObject}
         @test eltype(Symmetric(Matrix(T(rand(5, 5)))) * Matrix(T(rand(5, 5)))) == T
     end
 
-    @testset "$( string("Solve linear systems with ", T, "                     ") )" begin
+    @testset "$(string("Solve linear systems with ", T, "                     "))" begin
         A = Matrix(2one(T(3, 3)))
         b = Vector(T([2, 4, 8]))
 
         @test to_julia.(A \ b) ≈ [1.0, 2.0, 4.0]
     end
 
-    @testset "Array conversion tests" begin
+    return @testset "Array conversion tests" begin
         A = rand(3, 4)
         B = SX(4, 4)
         C = Matrix(A * B)

--- a/test/importexport.jl
+++ b/test/importexport.jl
@@ -1,5 +1,5 @@
 function test_importexport(::Type{T}) where {T <: CasadiSymbolicObject}
-    @testset "$( string("Import export functions ", T, "                       ") )" begin
+    return @testset "$(string("Import export functions ", T, "                       "))" begin
         M = rand(3, 3)
         R = rand(5, 3)
 

--- a/test/mathfuns.jl
+++ b/test/mathfuns.jl
@@ -1,5 +1,5 @@
 function test_mathfuns(::Type{T}) where {T <: CasadiSymbolicObject}
-    @testset "$( string("Math functions for ", T, "                            ") )" begin
+    return @testset "$(string("Math functions for ", T, "                            "))" begin
         x = randn()
 
         @test all(to_julia.(sincos(T(x))) .≈ sincos(x))

--- a/test/mathops.jl
+++ b/test/mathops.jl
@@ -1,11 +1,11 @@
 function test_mathops(::Type{T}) where {T <: CasadiSymbolicObject}
-    @testset "$( string("Unary operations for ", T, "                          ") )" begin
+    @testset "$(string("Unary operations for ", T, "                          "))" begin
         x = randn()
 
         @test to_julia(-T(x)) ≈ -x
     end
 
-    @testset "$( string("Binary operations for ", T, "                         ") )" begin
+    @testset "$(string("Binary operations for ", T, "                         "))" begin
         x = rand()
         y = rand()
 
@@ -17,7 +17,7 @@ function test_mathops(::Type{T}) where {T <: CasadiSymbolicObject}
         @test to_julia(T(x) \ T(y)) ≈ x \ y
     end
 
-    @testset "$( string("Comparisons for ", T, "                               ") )" begin
+    @testset "$(string("Comparisons for ", T, "                               "))" begin
         x = randn()
         y = x + rand()
 
@@ -28,7 +28,7 @@ function test_mathops(::Type{T}) where {T <: CasadiSymbolicObject}
         @test Bool(to_julia(T(x) == T(x)))
     end
 
-    @testset "$( string("Cross product for ", T, "                             ") )" begin
+    @testset "$(string("Cross product for ", T, "                             "))" begin
         n₁ = rand(3)
         n₂ = rand(3)
         c₁ = T(n₁)
@@ -42,7 +42,7 @@ function test_mathops(::Type{T}) where {T <: CasadiSymbolicObject}
         @test to_julia(c₁₂) == n₁₂
     end
 
-    @testset "Sum" begin
+    return @testset "Sum" begin
         a = T([1, 2, 3, 4])
         @test isequal(to_julia(sum(a)), 10)
         b = T(3, 3)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1,5 +1,5 @@
 function test_numbers(::Type{T}) where {T <: CasadiSymbolicObject}
-    @testset "$( string("Conversion of numeric ", T, " to Julia                ") )" begin
+    return @testset "$(string("Conversion of numeric ", T, " to Julia                "))" begin
         x₁ = rand()
         x₂ = rand(3)
         x₃ = [rand(1, 2); Inf -Inf]

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,5 +1,5 @@
 function test_types(::Type{T}) where {T <: CasadiSymbolicObject}
-    @testset "$( string("Console output for ", T, "                            ") )" begin
+    return @testset "$(string("Console output for ", T, "                            "))" begin
         @test (@capture_out show(T(1))) == "1"
         @test (@capture_out show(T([1; 2.1]))) == "[1, 2.1]"
         @test (@capture_out show(T([1 0; 2.1 -3]))) == "\n[[1, 0], \n [2.1, -3]]"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,7 @@
 J = b -> pyconvert(Bool, b)
 
 function test_utils(::Type{T}) where {T <: CasadiSymbolicObject}
-    @testset "$( string("Function 'substitute' for ", T, "                     ") )" begin
+    return @testset "$(string("Function 'substitute' for ", T, "                     "))" begin
         x = T("x")
         y = T("y")
         z = T("z")


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)