### PR TITLE
Canonicalize test suite: wrap independent units in @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,13 +10,15 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
 PythonCall = "0.9.24"
+SafeTestsets = "0.1, 1"
 Suppressor = "0.2"
 SymbolicUtils = "3.27.0, 4.3"
 julia = "1.6.1"
 
 [extras]
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Suppressor"]
+test = ["Test", "Suppressor", "SafeTestsets"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,30 +1,128 @@
-using Test, CasADi
-import LinearAlgebra: cross, ×, Symmetric
-import Suppressor: @capture_out
-using PythonCall
+using SafeTestsets, Test
 
-include("constructors.jl")
-include("generic.jl")
-include("importexport.jl")
-include("mathfuns.jl")
-include("mathops.jl")
-include("numbers.jl")
-include("types.jl")
-include("utils.jl")
+# Keep `using CasADi` in Main: the per-type test functions build CasADi
+# references and testset titles via `string(T)` (e.g. `Meta.parse(string("casadi.", T))`),
+# and `show`/`string` qualifies a type by its visibility in `Base.active_module()` (Main).
+# Without the bare names here, `string(SX)` becomes "CasADi.SX" and breaks that logic.
+using CasADi
 
-for i in [SX, MX]
-    test_constructors(i)
-    test_generic(i)
-    test_importexport(i)
-    test_mathfuns(i)
-    test_mathops(i)
-    test_numbers(i)
-    test_types(i)
-    test_utils(i)
+# Each independent test unit runs in its own module via `@safetestset`
+# (matching the canonical SciML structure). The per-type test functions
+# live in the included files; each `@safetestset` body `using`s what that
+# file needs, includes it, then calls the function for one symbolic type.
+
+@safetestset "Constructors SX" begin
+    using CasADi, Test
+    using PythonCall: pyconvert, Py
+    include("constructors.jl")
+    test_constructors(SX)
+end
+
+@safetestset "Generic SX" begin
+    using CasADi, Test
+    using PythonCall: pyconvert
+    import LinearAlgebra: Symmetric
+    include("generic.jl")
+    test_generic(SX)
+end
+
+@safetestset "Import/export SX" begin
+    using CasADi, Test
+    include("importexport.jl")
+    test_importexport(SX)
+end
+
+@safetestset "Math functions SX" begin
+    using CasADi, Test
+    include("mathfuns.jl")
+    test_mathfuns(SX)
+end
+
+@safetestset "Math operations SX" begin
+    using CasADi, Test
+    import LinearAlgebra: cross, ×
+    include("mathops.jl")
+    test_mathops(SX)
+end
+
+@safetestset "Numbers SX" begin
+    using CasADi, Test
+    include("numbers.jl")
+    test_numbers(SX)
+end
+
+@safetestset "Types SX" begin
+    using CasADi, Test
+    import Suppressor: @capture_out
+    include("types.jl")
+    test_types(SX)
+end
+
+@safetestset "Utils SX" begin
+    using CasADi, Test
+    using PythonCall: pyconvert
+    include("utils.jl")
+    test_utils(SX)
+end
+
+@safetestset "Constructors MX" begin
+    using CasADi, Test
+    using PythonCall: pyconvert, Py
+    include("constructors.jl")
+    test_constructors(MX)
+end
+
+@safetestset "Generic MX" begin
+    using CasADi, Test
+    using PythonCall: pyconvert
+    import LinearAlgebra: Symmetric
+    include("generic.jl")
+    test_generic(MX)
+end
+
+@safetestset "Import/export MX" begin
+    using CasADi, Test
+    include("importexport.jl")
+    test_importexport(MX)
+end
+
+@safetestset "Math functions MX" begin
+    using CasADi, Test
+    include("mathfuns.jl")
+    test_mathfuns(MX)
+end
+
+@safetestset "Math operations MX" begin
+    using CasADi, Test
+    import LinearAlgebra: cross, ×
+    include("mathops.jl")
+    test_mathops(MX)
+end
+
+@safetestset "Numbers MX" begin
+    using CasADi, Test
+    include("numbers.jl")
+    test_numbers(MX)
+end
+
+@safetestset "Types MX" begin
+    using CasADi, Test
+    import Suppressor: @capture_out
+    include("types.jl")
+    test_types(MX)
+end
+
+@safetestset "Utils MX" begin
+    using CasADi, Test
+    using PythonCall: pyconvert
+    include("utils.jl")
+    test_utils(MX)
 end
 
 ## Test examples
-@testset "Test first example                                " begin
+@safetestset "Test first example                                " begin
+    using CasADi, Test
+
     x = SX("x")
     y = SX("y")
     α = 1
@@ -43,7 +141,9 @@ end
     @test sol["x"] ≈ [0.9999999999999899, 0.9999999999999792]
 end
 
-@testset "Test second example                               " begin
+@safetestset "Test second example                               " begin
+    using CasADi, Test
+
     opti = Opti()
 
     x = variable!(opti)


### PR DESCRIPTION
## What

Converts CasADi's test suite to the canonical SciML structure where each independent test unit runs in its own module via `@safetestset` (isolation between tests + world-age safety), matching OrdinaryDiffEq.

## Before / after

The suite previously `include`d eight files defining parametrized `test_X(::Type{T})` functions and drove them from a `for T in [SX, MX]` loop at `runtests.jl` file scope, plus two trailing plain-`@testset` example blocks (so all units shared one `Main` module).

`runtests.jl` now wraps each (function, type) call and each example in its own `@safetestset`. The eight included files (`constructors.jl`, `generic.jl`, ...) are **unchanged**; each `@safetestset` body carries the `using`/`import` lines that file relies on, then `include(...)`, then the function call:

- `constructors.jl` / `utils.jl`: `using CasADi, Test` + `using PythonCall: pyconvert, Py` (Py only for constructors)
- `generic.jl`: `using PythonCall: pyconvert` + `import LinearAlgebra: Symmetric`
- `mathops.jl`: `import LinearAlgebra: cross, ×`
- `types.jl`: `import Suppressor: @capture_out`
- the rest only need `using CasADi, Test`

## Why `using CasADi` stays in Main

The test functions build CasADi references and testset titles via `string(T)` (e.g. `eval(Meta.parse(string("casadi.", T)))`). `show`/`string` qualifies a type by its visibility in `Base.active_module()` (Main), **not** the module the code runs in. Without the bare names in Main, `string(SX)` renders as `"CasADi.SX"`, which both relabels every testset and breaks the `eval(Meta.parse("casadi.CasADi.SX"))` logic (observed locally as `module 'casadi' has no attribute 'CasADi'`). So `using CasADi` is kept at `runtests.jl` top level.

## Behavior-preserving

- Inner grouping `@testset`s inside each unit stay plain `@testset` (the unit-level `@safetestset` already isolates).
- No test logic, assertions, or which-tests-run changed. The pre-existing `@macroexpand`'d "Construct constant" block in `constructors.jl` still does not execute (preserved as-is).
- Added `SafeTestsets` to `[extras]`, `[targets].test`, and `[compat] = "0.1, 1"`.

## Verification (local)

Ran `Pkg.test()` on Julia 1.11 before and after. Both pass. Aggregate pass total is **285 = 285**, unchanged; per-unit breakdown matches (e.g. Constructors=7, Generic=90, MathOps=18 per type). 0 failures, 0 errors.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)