### PR TITLE
Use nameof to build casadi Python attribute paths from types

### DIFF
--- a/src/array_utils.jl
+++ b/src/array_utils.jl
@@ -57,35 +57,35 @@ Base.lastindex(x::CasadiSymbolicObject, j::Int) = size(x, j)
 
 ## one, zero, zeros, ones
 function Base.one(::Type{C}) where {C <: CasadiSymbolicObject}
-    return C(getproperty(casadi, Symbol(C)).eye(1))
+    return C(getproperty(casadi, nameof(C)).eye(1))
 end
 function Base.one(x::C) where {C <: CasadiSymbolicObject}
     return if size(x, 1) == size(x, 2)
-        C(getproperty(casadi, Symbol(C)).eye(size(x, 1)))
+        C(getproperty(casadi, nameof(C)).eye(size(x, 1)))
     else
         throw(DimensionMismatch("multiplicative identity defined only for square matrices"))
     end
 end
 
 function Base.zero(::Type{C}) where {C <: CasadiSymbolicObject}
-    return C(getproperty(casadi, Symbol(C)).zeros())
+    return C(getproperty(casadi, nameof(C)).zeros())
 end
 function Base.zero(x::C) where {C <: CasadiSymbolicObject}
-    return C(getproperty(casadi, Symbol(C)).zeros(size(x)))
+    return C(getproperty(casadi, nameof(C)).zeros(size(x)))
 end
 
 function Base.ones(::Type{C}, j::Integer) where {C <: CasadiSymbolicObject}
-    return C(getproperty(casadi, Symbol(C)).ones(j))
+    return C(getproperty(casadi, nameof(C)).ones(j))
 end
 function Base.ones(::Type{C}, j1::Integer, j2::Integer) where {C <: CasadiSymbolicObject}
-    return C(getproperty(casadi, Symbol(C)).ones(j1, j2))
+    return C(getproperty(casadi, nameof(C)).ones(j1, j2))
 end
 
 function Base.zeros(::Type{C}, j::Integer) where {C <: CasadiSymbolicObject}
-    return C(getproperty(casadi, Symbol(C)).zeros(j))
+    return C(getproperty(casadi, nameof(C)).zeros(j))
 end
 function Base.zeros(::Type{C}, j1::Integer, j2::Integer) where {C <: CasadiSymbolicObject}
-    return C(getproperty(casadi, Symbol(C)).zeros(j1, j2))
+    return C(getproperty(casadi, nameof(C)).zeros(j1, j2))
 end
 
 ## Size related operations

--- a/test/shared/constructors.jl
+++ b/test/shared/constructors.jl
@@ -7,13 +7,13 @@ function test_constructors(::Type{T}) where {T <: CasadiSymbolicObject}
         V = T([1; 2; 3])
         M = T([1 2; 3 4; 5 6])
 
-        @test J(casadi.is_equal(eval(Meta.parse(string("casadi.", T)))(1), scalar1, 1))
-        @test J(casadi.is_equal(eval(Meta.parse(string("casadi.", T)))(1.0), scalar2, 1))
+        @test J(casadi.is_equal(eval(Meta.parse(string("casadi.", nameof(T))))(1), scalar1, 1))
+        @test J(casadi.is_equal(eval(Meta.parse(string("casadi.", nameof(T))))(1.0), scalar2, 1))
         @test J(casadi.is_equal(scalar1, scalar2, 1))
-        @test J(casadi.is_equal(eval(Meta.parse(string("casadi.", T)))([1; 2; 3]), V, 1))
+        @test J(casadi.is_equal(eval(Meta.parse(string("casadi.", nameof(T))))([1; 2; 3]), V, 1))
         @test J(
             casadi.is_equal(
-                eval(Meta.parse(string("casadi.", T)))(
+                eval(Meta.parse(string("casadi.", nameof(T))))(
                     [
                         [1, 2], [3, 4], [5, 6],
                     ]
@@ -23,14 +23,14 @@ function test_constructors(::Type{T}) where {T <: CasadiSymbolicObject}
     end
 
     @testset "$(string("Construct variable ", T, " vector and matrix          "))" begin
-        v = eval(Meta.parse(string("casadi.", T, ".sym")))("v", 3)
+        v = eval(Meta.parse(string("casadi.", nameof(T), ".sym")))("v", 3)
         V = T("V", 3)
         v_val = rand(3)
         @test pyconvert(
             Bool, casadi.is_equal(casadi.substitute(v, v, v_val), casadi.substitute(V, V, v_val), 1)
         )
 
-        m = eval(Meta.parse(string("casadi.", T, ".sym")))("m", 2, 4)
+        m = eval(Meta.parse(string("casadi.", nameof(T), ".sym")))("m", 2, 4)
         M = T("M", 2, 4)
         m_val = Py(rand(2, 4)).__array__()
         @test J(casadi.is_equal(casadi.substitute(m, m, m_val), casadi.substitute(M, M, m_val), 1))
@@ -38,10 +38,10 @@ function test_constructors(::Type{T}) where {T <: CasadiSymbolicObject}
 
     @testset "$(string("AbstractFloat and Integer constructors for ", T, "    "))" begin
         af = [1.2; -0.0; -4.3]
-        @test J(casadi.is_equal(T(af)', casadi.transpose(eval(Meta.parse(string("casadi.", T)))(af)), 2))
+        @test J(casadi.is_equal(T(af)', casadi.transpose(eval(Meta.parse(string("casadi.", nameof(T))))(af)), 2))
 
         int = [1; 0; -2]
-        @test J(casadi.is_equal(T(int)', casadi.transpose(eval(Meta.parse(string("casadi.", T)))(int)), 2))
+        @test J(casadi.is_equal(T(int)', casadi.transpose(eval(Meta.parse(string("casadi.", nameof(T))))(int)), 2))
     end
 
     return @testset "$(string("Other constructors tests for ", T, "                  "))" begin


### PR DESCRIPTION
## Summary

Fixes the **Core** and **Downgrade** test lanes, which fail identically on lts / 1 / pre with:

```
Python: AttributeError: module 'casadi' has no attribute 'CasADi.MX'
```

### Root cause

Two places build a Python attribute path from a Julia type name:

- `src/array_utils.jl` — `one`/`zero`/`ones`/`zeros` do `getproperty(casadi, Symbol(C))`
- `test/shared/constructors.jl` — `eval(Meta.parse(string("casadi.", T)))` / `string("casadi.", T, ".sym")`

`Symbol(::Type)` and `string(::Type)` print the **qualified** name (`CasADi.SX`, `CasADi.MX`) whenever `CasADi` is not `using`-ed into the current active module. Under the SciMLTesting v1.2+ folder-based `run_tests` harness, each group file is `include`-d into a fresh (anonymous) module via `@safetestset ... include(...)`, so `Base.active_module()` is not a module where the bare type names are in scope — the qualified name leaks into the Python attribute lookup and CasADi (Python) has no `CasADi.MX` attribute.

### Fix

Use `nameof`, which returns the bare type symbol (`:SX`, `:MX`) regardless of `Base.active_module()`:

- `src/array_utils.jl`: `getproperty(casadi, nameof(C))` (8 sites). This is a real API bug that also affects **downstream users** calling `one`/`zero`/`ones`/`zeros` on `SX`/`MX` from a module that hasn't imported `CasADi` — not just the test harness.
- `test/shared/constructors.jl`: `string("casadi.", nameof(T))` / `string("casadi.", nameof(T), ".sym")` (8 sites).

No `[compat]` floor change, no dependency change.

### Validation

`GROUP=Core Pkg.test` on Julia 1.12.6 — exit 0, **285/285 Core pass**:

```
Core/constructors_tests.jl |   14     14
Core/examples_tests.jl     |    3      3   (incl. Ipopt)
Core/generic_tests.jl      |  180    180
Core/importexport_tests.jl |   16     16
Core/mathfuns_tests.jl     |    6      6
Core/mathops_tests.jl      |   36     36
Core/numbers_tests.jl      |   14     14
Core/types_tests.jl        |    8      8
Core/utils_tests.jl        |    8      8
     Testing CasADi tests passed
```

The Downgrade lane shares the identical test-run bug (its resolve + build steps already pass), so this single fix greens it as well.

Runic check passes on both changed files.

---

**Please ignore until reviewed by @ChrisRackauckas.** Opened as draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)