### PR TITLE
Fix Downgrade segfault: bump PythonCall floor to 0.9.30 (exclude Python 3.14)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
-PythonCall = "0.9.24"
+PythonCall = "0.9.30"
 SafeTestsets = "0.0.1, 0.1"
 SciMLTesting = "1"
 Suppressor = "0.2"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The `Downgrade (lts)` lane is red: it resolves and builds fine, but `Pkg.test` crashes with `Package CasADi errored during testing (received signal: 11)` — a segfault at `constructors_tests.jl:3`.

The backtrace is entirely inside **CPython 3.14.6** (`PyObject_GC_UnTrack` / `list_dealloc`) during `import casadi` via PythonCall's `PyImport_Import`.

## Root cause

The Downgrade lane pins every dep to its compat floor. `PythonCall = "0.9.24"` (the current floor) ships a `CondaPkg.toml` that constrains `python >=3.8,<4`. conda-forge now publishes **CPython 3.14**, so CondaPkg installs `python 3.14.6` + the `casadi 3.7.x` `py314` build. That casadi build's swig `_casadi` extension is broken under this combination — locally it surfaces as `ModuleNotFoundError: No module named '_casadi'`, and in CI as a hard SIGSEGV inside the 3.14 GC.

PythonCall gained a python upper-bound only later:
- `0.9.30`: `python >=3.10,<3.14` (first to fully exclude 3.14)
- `0.9.31+`: `python >=3.10,!=3.14.0,!=3.14.1,<4` (allows 3.14.2+, i.e. the broken 3.14.6)

## Fix

Bump the `PythonCall` compat floor `0.9.24 -> 0.9.30`. This keeps the downgraded environment on a Python (3.13) with a working casadi build. The current released PythonCall (`0.9.35`, used by the already-green Tests lane) still satisfies `>=0.9.30`, so the upper lanes are unaffected.

## Validation (local, Julia 1.10 / lts)

- **Floor 0.9.24** -> python 3.14.6, casadi 3.7.2 `py314`: `import casadi` fails (`ModuleNotFoundError: No module named '_casadi'`; CI = SIGSEGV). Reproduced.
- **Floor 0.9.30** -> python 3.13.5, casadi 3.7.0 `py313`: full downgraded Core suite passes **285/285**, 0 fail / 0 error / no segfault:
  - `constructors 14/14` (the file that segfaulted), `generic 180/180`, `mathops 36/36`, `importexport 16/16`, `numbers 14/14`, `types 8/8`, `utils 8/8`, `mathfuns 6/6`, `examples 3/3`.

Downgrade resolution (`julia-downgrade-compat` merged-extras mode, `--julia=1.10`) succeeds and resolves PythonCall to 0.9.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)