### PR TITLE
Release prep: bump to 1.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CasADi"
 uuid = "c49709b8-5c63-11e9-2fb2-69db5844192f"
 authors = ["Iordanis Chatzinikolaidis <ch.iordanis@outlook.com>", "Vincent Du <vincent.duyuan@gmail.com>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Version-bump-only release PR. Bug fix (Symbol->nameof for casadi Python attribute paths) plus PythonCall compat floor raise (0.9.24->0.9.30), already reviewed/merged via PR #30/#31.