### PR TITLE
Bump CasADi to v1.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CasADi"
 uuid = "c49709b8-5c63-11e9-2fb2-69db5844192f"
 authors = ["Iordanis Chatzinikolaidis <ch.iordanis@outlook.com>", "Vincent Du <vincent.duyuan@gmail.com>"]
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Bumps `CasADi` **v1.2.1 → v1.2.2** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Document CasADi public API and require SciMLTesting 2.4 (#35) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)